### PR TITLE
Adds readme builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Spiral Application installer
 
-[App Skeleton](https://github.com/spiral/app) | [**Documentation
-**](https://spiral.dev/docs) | [Discord](https://discord.gg/TFeEmCs) | [Twitter](https://twitter.com/spiralphp) | [Contributing](https://spiral.dev/docs/about-contributing/)
+[App Skeleton](https://github.com/spiral/app) | [**Documentation**](https://spiral.dev/docs) | [Discord](https://discord.gg/TFeEmCs) | [Twitter](https://twitter.com/spiralphp) | [Contributing](https://spiral.dev/docs/about-contributing/)
 
 ![Installer](https://user-images.githubusercontent.com/773481/208850084-891a9d6f-3e70-4a06-af57-4e63c37c9c47.png)
 

--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,8 @@
         ],
         "rr:download": "rr get-binary",
         "rr:download-protoc": "rr download-protoc-binary",
+        "test": "vendor/bin/phpunit",
+        "test-coverage": "vendor/bin/phpunit --coverage",
         "psalm:config": "psalm",
         "deptrack": [
             "deptrac analyze --report-uncovered"

--- a/installer/Configurator.php
+++ b/installer/Configurator.php
@@ -52,6 +52,7 @@ final class Configurator extends AbstractInstaller
         $conf->createRoadRunnerConfig();
         $conf->runCommands();
         $conf->showInstructions();
+        $conf->updateReadme();
         $conf->removeInstaller();
         $conf->finalize();
     }
@@ -107,6 +108,62 @@ final class Configurator extends AbstractInstaller
         });
     }
 
+    private function updateReadme(): void
+    {
+        $readme = $this->projectRoot . '/README.md';
+        if (!\file_exists($readme)) {
+            return;
+        }
+
+        $content = \file_get_contents($readme);
+        $content = \str_replace(
+            ':app_name',
+            \sprintf('My super %s application', $this->application->getName()),
+            $content
+        );
+
+        $nextSteps = ['## Next steps'];
+
+        foreach ($this->application->getInstructions() as $index => $instruction) {
+            $nextSteps[] = \sprintf('%d. %s', $index + 1, $instruction);
+        }
+
+        $showPackageInstruction = function (Package $package) use (&$nextSteps): void {
+            if ($package->getInstructions() === []) {
+                return;
+            }
+
+            $nextSteps[] = \sprintf('### %s', $package->getTitle());
+            foreach ($package->getInstructions() as $index => $instruction) {
+                $nextSteps[] = \sprintf('%s. %s', (int)$index + 1, $instruction);
+            }
+        };
+
+        // from required packages
+        foreach ($this->application->getPackages() as $package) {
+            $showPackageInstruction($package);
+        }
+
+        // from installed optional packages
+        foreach ($this->application->getQuestions() as $question) {
+            foreach ($question->getOptions() as $option) {
+                foreach ($option instanceof Option ? $option->getPackages() : [] as $package) {
+                    if ($this->application->isPackageInstalled($package)) {
+                        $showPackageInstruction($package);
+                    }
+                }
+            }
+        }
+
+        $content = \str_replace(
+            ':next_steps',
+            $nextSteps,
+            $content
+        );
+
+        \file_put_contents($readme, $content);
+    }
+
     private function showInstructions(): void
     {
         $this->io->write('  <comment>Next steps:</comment>');
@@ -117,10 +174,11 @@ final class Configurator extends AbstractInstaller
         }
 
         $showPackageInstruction = function (Package $package): void {
-            if ($package->getInstructions() !== []) {
-                $this->io->write(\sprintf('  <comment>%s</comment>', $package->getTitle()));
+            if ($package->getInstructions() === []) {
+                return;
             }
 
+            $this->io->write(\sprintf('  <comment>%s</comment>', $package->getTitle()));
             foreach ($package->getInstructions() as $index => $instruction) {
                 $this->io->write(\sprintf('  %s. %s', (int)$index + 1, $instruction));
             }

--- a/installer/Configurator.php
+++ b/installer/Configurator.php
@@ -122,7 +122,7 @@ final class Configurator extends AbstractInstaller
             $content
         );
 
-        $nextSteps = ['## Next steps'];
+        $nextSteps = ['## Configuration'];
 
         foreach ($this->application->getInstructions() as $index => $instruction) {
             $nextSteps[] = \sprintf('%d. %s', $index + 1, $instruction);

--- a/installer/Configurator.php
+++ b/installer/Configurator.php
@@ -122,7 +122,7 @@ final class Configurator extends AbstractInstaller
         $nextSteps = ['## Configuration'];
 
         foreach ($this->application->getInstructions() as $index => $instruction) {
-            $nextSteps[] = \sprintf('%d. %s', $index + 1, $instruction);
+            $nextSteps[] = \sprintf('%d. %s', $index + 1, \strip_tags($instruction));
         }
 
         $showPackageInstruction = function (Package $package) use (&$nextSteps): void {
@@ -132,7 +132,7 @@ final class Configurator extends AbstractInstaller
 
             $nextSteps[] = \sprintf('### %s', $package->getTitle());
             foreach ($package->getInstructions() as $index => $instruction) {
-                $nextSteps[] = \sprintf('%s. %s', (int)$index + 1, $instruction);
+                $nextSteps[] = \sprintf('%s. %s', (int)$index + 1, \strip_tags($instruction));
             }
         };
 

--- a/installer/Configurator.php
+++ b/installer/Configurator.php
@@ -116,11 +116,8 @@ final class Configurator extends AbstractInstaller
         }
 
         $content = \file_get_contents($readme);
-        $content = \str_replace(
-            ':app_name',
-            \sprintf('My super %s application', $this->application->getName()),
-            $content
-        );
+        $content = \str_replace(':app_name', $this->application->getName(), $content);
+        $content = \str_replace(':date', (new \DateTime())->format('r'), $content);
 
         $nextSteps = ['## Configuration'];
 

--- a/installer/Configurator.php
+++ b/installer/Configurator.php
@@ -157,7 +157,7 @@ final class Configurator extends AbstractInstaller
 
         $content = \str_replace(
             ':next_steps',
-            $nextSteps,
+            \implode(\PHP_EOL, $nextSteps),
             $content
         );
 

--- a/installer/Generator/EnvConfigurator.php
+++ b/installer/Generator/EnvConfigurator.php
@@ -83,7 +83,7 @@ final class EnvConfigurator
             priority: 2
         );
         $this->addGroup(
-            values: ['VERBOSITY_LEVEL' => '1 # 0, 1, 2'],
+            values: ['VERBOSITY_LEVEL' => 'verbose # basic, verbose, debug'],
             comment: 'Verbosity level',
             priority: 3
         );

--- a/installer/Package/SentryBridge.php
+++ b/installer/Package/SentryBridge.php
@@ -20,7 +20,7 @@ final class SentryBridge extends Package
             new Env(),
         ],
         array $instructions = [
-            'Please, configure the <comment>SENTRY_DSN</comment> environment variable',
+            'Please, configure the <comment>`SENTRY_DSN`</comment> environment variable',
             'Documentation: <comment>https://spiral.dev/docs/extension-sentry</comment>',
         ]
     ) {

--- a/installer/Resources/common/README.md
+++ b/installer/Resources/common/README.md
@@ -48,10 +48,21 @@ composer rr:download-protoc
 
 - [**Spiral Framework documentation**](https://spiral.dev/docs)
 - [**RoadRunner documentation**](https://roadrunner.dev/docs)
-- Spiral Framework [community packages](https://github.com/spiral-packages).
-- [Birddog](https://github.com/roadrunner-server/birddog): OpenSource tool for monitoring RoadRunner instances.
-- Support us here: [Link](https://github.com/sponsors/roadrunner-server)
+- [Community packages](https://github.com/spiral-packages).
+- [Birddog](https://github.com/roadrunner-server/birddog) — OpenSource tool for monitoring RoadRunner instances.
+- [Support us](https://github.com/sponsors/roadrunner-server)
 - [Contributing](https://spiral.dev/docs/about-contributing/)
 
-> **Note**:
-> If you have any questions or suggestions join our [discord server](https://discord.gg/TFeEmCs).
+## Support
+
+If you have any questions or need help with the project, please don't hesitate to reach out! You can find us on Discord
+at the following link:
+
+[Discord Server](https://discord.gg/TFeEmCs)
+
+Alternatively, you can create an issue on GitHub to report a bug or request a feature:
+
+[Create an Issue on GitHub](https://github.com/spiral/framework/issues/new/choose)
+
+We welcome any feedback or suggestions you may have, and are always happy to help troubleshoot any issues you may
+encounter.

--- a/installer/Resources/common/README.md
+++ b/installer/Resources/common/README.md
@@ -1,5 +1,14 @@
 # :app_name
 
+[**Documentation**](https://spiral.dev/docs) | [Discord](https://discord.gg/TFeEmCs) | [Twitter](https://twitter.com/spiralphp) | [Contributing](https://spiral.dev/docs/about-contributing/)
+
+## About Spiral Framework
+
+Spiral Framework is a High-Performance Long-Living Full-Stack framework and group of over sixty PSR-compatible
+components. The Framework execution model based on a hybrid runtime where some services (GRPC, Queue, WebSockets, etc.)
+handled by RoadRunner application server and the PHP code of your application stays in memory permanently (anti-memory
+leak tools included).
+
 ## Server Requirements
 
 Make sure that your server is configured with following PHP version and extensions:
@@ -20,3 +29,31 @@ After the project has been created and installed, start RoadRunner server using 
 <br />
 
 Once you have started RoadRunner server, your application will be accessible in your web browser at `http://localhost:8080`.
+
+## Console commands
+
+### Download or update RoadRunner
+
+Allows to install the latest version of the RoadRunner compatible with your environment (operating system, processor
+architecture, runtime, etc...).
+
+```bash
+composer rr:download
+# or
+./vendor/bin/rr get-binary
+```
+
+### Download or update protoc get GRPC plugin
+
+Allows to install the latest version of the `protoc-gen-php-grpc` file compatible with your environment (operating
+system, processor architecture, runtime, etc...).
+
+```bash
+composer rr:download-protoc
+# or
+./vendor/bin/rr download-protoc-binary
+```
+
+License
+--------
+MIT License (MIT). Please see [`LICENSE`](./LICENSE) for more information. Maintained by [Spiral Scout](https://spiralscout.com).

--- a/installer/Resources/common/README.md
+++ b/installer/Resources/common/README.md
@@ -1,0 +1,22 @@
+# :app_name
+
+## Server Requirements
+
+Make sure that your server is configured with following PHP version and extensions:
+
+* PHP 8.1+, 64bit
+* [mb-string](https://www.php.net/manual/en/intro.mbstring.php) extension
+
+:next_steps
+
+<br />
+
+After the project has been created and installed, start RoadRunner server using the following command:
+
+```bash
+./rr serve
+```
+
+<br />
+
+Once you have started RoadRunner server, your application will be accessible in your web browser at `http://localhost:8080`.

--- a/installer/Resources/common/README.md
+++ b/installer/Resources/common/README.md
@@ -1,34 +1,24 @@
-# :app_name
+# My super :app_name application
 
-[**Documentation**](https://spiral.dev/docs) | [Discord](https://discord.gg/TFeEmCs) | [Twitter](https://twitter.com/spiralphp) | [Contributing](https://spiral.dev/docs/about-contributing/)
-
-## About Spiral Framework
-
-Spiral Framework is a High-Performance Long-Living Full-Stack framework and group of over sixty PSR-compatible
-components. The Framework execution model based on a hybrid runtime where some services (GRPC, Queue, WebSockets, etc.)
-handled by RoadRunner application server and the PHP code of your application stays in memory permanently (anti-memory
-leak tools included).
-
-## Server Requirements
-
-Make sure that your server is configured with following PHP version and extensions:
-
-* PHP 8.1+, 64bit
-* [mb-string](https://www.php.net/manual/en/intro.mbstring.php) extension
+Was created by [spiral/installer](https://github.com/spiral/installer) with `:app_name` skeleton at **:date**.
 
 :next_steps
 
-<br />
+## Usage
 
-After the project has been created and installed, start RoadRunner server using the following command:
+if you need to start RoadRunner server after the project has been configured use the following command:
 
 ```bash
 ./rr serve
 ```
 
+> **Note**:
+> Read more about the RoadRunner CLI commands in the [documentation](https://roadrunner.dev/docs/app-server-cli/2.x/en).
+
 <br />
 
-Once you have started RoadRunner server, your application will be accessible in your web browser at `http://localhost:8080`.
+After starting the RoadRunner server with HTTP plugin, you will be able to access your application in a web
+browser by going to a specific URL: http://127.0.0.1:8080.
 
 ## Console commands
 
@@ -54,6 +44,14 @@ composer rr:download-protoc
 ./vendor/bin/rr download-protoc-binary
 ```
 
-License
---------
-MIT License (MIT). Please see [`LICENSE`](./LICENSE) for more information. Maintained by [Spiral Scout](https://spiralscout.com).
+## Useful resources
+
+- [**Spiral Framework documentation**](https://spiral.dev/docs)
+- [**RoadRunner documentation**](https://roadrunner.dev/docs)
+- Spiral Framework [community packages](https://github.com/spiral-packages).
+- [Birddog](https://github.com/roadrunner-server/birddog): OpenSource tool for monitoring RoadRunner instances.
+- Support us here: [Link](https://github.com/sponsors/roadrunner-server)
+- [Contributing](https://spiral.dev/docs/about-contributing/)
+
+> **Note**:
+> If you have any questions or suggestions join our [discord server](https://discord.gg/TFeEmCs).


### PR DESCRIPTION
### Generated README.md Example

# My super Web application

Was created by [spiral/installer](https://github.com/spiral/installer) with `Web` skeleton at **Thu, 22 Dec 2022 16:48:05 +0400**.

## Configuration
1. Please, configure the environment variables in the <comment>.env</comment> file at the application's root.
2. Read documentation about Spiral Framework: <comment>https://spiral.dev/docs</comment></info>
### RoadRunnerBridge
1. The RoadRunner configuration is available in the <comment>.rr.yaml</comment> file at the root of the application
2. Documentation: <comment>https://spiral.dev/docs/packages-roadrunner-bridge</comment>
### CycleBridge
1. Database configuration file available here: <comment>app/config/database.php</comment>
2. Migrations configuration file available here: <comment>app/config/migration.php</comment>
3. Cycle ORM configuration file available here: <comment>app/config/cycle.php</comment>
4. Documentation: <comment>https://spiral.dev/docs/packages-cycle-bridge</comment>
### SpiralValidator
1. Read more about validation in the Spiral Framework: <comment>https://spiral.dev/docs/validation-factory</comment>
2. Documentation: <comment>https://spiral.dev/docs/validation-spiral</comment>
### StemplerBridge
1. Read more about views in the Spiral Framework: <comment>https://spiral.dev/docs/views-configuration</comment>
2. Documentation: <comment>https://spiral.dev/docs/stempler-configuration</comment>
### Scheduler
1. Documentation: <comment>https://spiral.dev/docs/packages-scheduler</comment>
### TemporalBridge
1. Documentation: <comment>https://spiral.dev/docs/packages-temporal-bridge</comment>
### SentryBridge
1. Please, configure the <comment>`SENTRY_DSN`</comment> environment variable
2. Documentation: <comment>https://spiral.dev/docs/extension-sentry</comment>

## Usage

if you need to start RoadRunner server after the project has been configured use the following command:

```bash
./rr serve
```

> **Note**:
> Read more about the RoadRunner CLI commands in the [documentation](https://roadrunner.dev/docs/app-server-cli/2.x/en).

<br />

After starting the RoadRunner server with HTTP plugin, you will be able to access your application in a web
browser by going to a specific URL: http://127.0.0.1:8080.

## Console commands

### Download or update RoadRunner

Allows to install the latest version of the RoadRunner compatible with your environment (operating system, processor
architecture, runtime, etc...).

```bash
composer rr:download
# or
./vendor/bin/rr get-binary
```

### Download or update protoc get GRPC plugin

Allows to install the latest version of the `protoc-gen-php-grpc` file compatible with your environment (operating
system, processor architecture, runtime, etc...).

```bash
composer rr:download-protoc
# or
./vendor/bin/rr download-protoc-binary
```

## Useful resources

- [**Spiral Framework documentation**](https://spiral.dev/docs)
- [**RoadRunner documentation**](https://roadrunner.dev/docs)
- Spiral Framework [community packages](https://github.com/spiral-packages).
- [Birddog](https://github.com/roadrunner-server/birddog): OpenSource tool for monitoring RoadRunner instances.
- Support us here: [Link](https://github.com/sponsors/roadrunner-server)
- [Contributing](https://spiral.dev/docs/about-contributing/)

> **Note**:
> If you have any questions or suggestions join our [discord server](https://discord.gg/TFeEmCs).